### PR TITLE
Add rule for imaginary number i

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ There are a few symbols that could not be directly transferred to the language a
 - theta --> `[theta]`
 - powers --> `^` (for instance, 5 squared would be `5^2`)
 - `e` constant --> `[e]`
+- `i` imaginary number --> `[i]`
 - Store --> `->` (same for such things as `>DMS`: `->DMS`)
 - Roots --> `[root]^` (for instance, square root would be `[root]^2`)
 

--- a/src/tokens.cpp
+++ b/src/tokens.cpp
@@ -46,7 +46,7 @@ struct ConvertRule {
 
 /// References to lists defined after functions.
 extern struct Token StandardTokens[199];
-extern struct TwoByte CalcVars[303];
+extern struct TwoByte CalcVars[304];
 extern struct ConvertRule Replacements[39];
 
 /// string -> token mapping
@@ -1194,6 +1194,7 @@ struct TwoByte CalcVars[] = {
     {TOPOLAR, "->Polar"},
     {VAR_E, "[e]"},  // e by itself is impossible, and dangerous (imagine Disp
                      // "Hello"!)
+    {IMAG_I, "[i]"}, // Lower case i for imaginary numbers
     {SINREG, "SinReg "},
     {LOGISTIC, "Logistic "},
     {LINREGTTEST, "LinRegTTest "},


### PR DESCRIPTION
## General
Awesome project! 😸 Makes writing basic for the TI84Plus a less tedious exercise.


Had an issue where I couldn't use the imaginary number `i`. The letter i is interpreted as a regular I. Found no way to use it. Seems like there is no rule for it, so added one. Some quick examples about the behavior before below 🙂 

I suggest having a simple `[i]` token for the imaginary number i. This is the simplest way, and consistent with the rest of the rules. Implemented here, and works like expected. Imports into calculator and TI84plus like a charm.


## Example from before this change
TI Connect CE:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/e6ad0b6a-d239-4196-b40c-671160c02a6d" />

Decompiled with tibasic program:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/5aa36608-f461-4690-8f21-bffa2f5c66f8" />

